### PR TITLE
Restore full cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 # create data file and commit it to this repo
 - cd qx-contrib
 - "../qooxdoo-compiler/qx config set github.token $TOKEN"
-- "../qooxdoo-compiler/qx contrib update --verbose --search --file cache.json"
+- "../qooxdoo-compiler/qx contrib update --verbose --search --all-versions --file cache.json"
 - |
   if ! git diff --quiet --exit-code; then
     git add cache.json && git commit -m "Update catalog" && git push && echo "Updated contrib cache."


### PR DESCRIPTION
This fixes the problem reported on Gitter that older versions in `contrib.json` cannot be automatically installed because they are not referenced in the cache. This problem is not easy to fix more elegantly. I tried to improve `qx contrib install` but there is currently no way around the travis cron job that creates the bloated cache. The reason is that we cannot dynamically do a partial download of a particular repository's release data without requiring a GitHub token. 